### PR TITLE
Chor/reactive wait until start minute

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,6 +8,7 @@ POLKADOT_MULTISIG=12dZDawZByadbVmjBUv96M55KbZRLsbnRdfjrhmHtSFvkh48,16GK2GsTbNHaV
 THRESHOLD=2
 PROPOSER_MNEMONIC='candy maple cake sugar pudding cream honey rich smooth crumble sweet treat'
 SUBSCAN_API_KEY=123
+SKIP_WAIT=true
 
 # For testing
 NOTION_TEST_API_TOKEN=

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -31,7 +31,7 @@ async function main() {
     console.log("Waiting until the start minute...");
     checkForVotes(); // check for votes immediately
 
-    //await waitUntilStartMinute();
+    await waitUntilStartMinute();
 
     console.log("Refreshing referendas...");
     refreshReferendas(); // with 7 app instances, we can't start all of them at the same time (because of the rate limit)

--- a/backend/src/utils/utils.ts
+++ b/backend/src/utils/utils.ts
@@ -157,6 +157,12 @@ export async function sleep(ms: number) {
 }
 
 export async function waitUntilStartMinute(): Promise<void> {
+    if (process.env.SKIP_WAIT) {
+        console.log("Skipping wait until start minute...");
+        return;
+    }
+
+    console.log("Waiting until start minute...");
     const startMinute = process.env.START_MINUTE ? parseInt(process.env.START_MINUTE, 10) : 0;
     const now = new Date();
     const currentMinute = now.getMinutes();


### PR DESCRIPTION
Reactivates `waitUntilStartMinute()`, but adds a `SKIP_WAIT` environment variable, so this function can be skipped, when testing.
