### PR TITLE
Turns off StatusBadges on main page

### DIFF
--- a/extension/src/components/SettingsMore.vue
+++ b/extension/src/components/SettingsMore.vue
@@ -335,7 +335,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, onUnmounted } from 'vue'
 import { ApiService } from '../utils/apiService'
 
 interface Props {
@@ -377,10 +377,27 @@ interface ActivityItem {
   timestamp: string
 }
 
-defineProps<Props>()
-defineEmits<{
+const props = defineProps<Props>()
+const emit = defineEmits<{
   close: []
 }>()
+
+// Add ESC key handler
+const handleEscKey = (event: KeyboardEvent) => {
+  if (event.key === 'Escape' && props.show) {
+    emit('close')
+  }
+}
+
+// Add and remove event listener
+onMounted(() => {
+  window.addEventListener('keydown', handleEscKey)
+  loadData()
+})
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleEscKey)
+})
 
 // Data
 const activeSection = ref<'dao-config' | 'preferences' | 'voting-history' | 'activity-log' | 'data-sync' | 'help' | 'about'>('dao-config')
@@ -491,10 +508,6 @@ const getActivityIcon = (type: string): string => {
 const formatDate = (dateString: string) => {
   return new Date(dateString).toLocaleDateString()
 }
-
-onMounted(() => {
-  loadData()
-})
 </script>
 
 <style scoped>

--- a/extension/src/components/TeamWorkflow.vue
+++ b/extension/src/components/TeamWorkflow.vue
@@ -343,7 +343,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import type { ProposalData, TeamMember } from '../types'
 import StatusBadge from './StatusBadge.vue'
 import { ApiService } from '../utils/apiService'
@@ -354,9 +354,26 @@ interface Props {
 }
 
 const props = defineProps<Props>()
-defineEmits<{
+const emit = defineEmits<{
   close: []
 }>()
+
+// Add ESC key handler
+const handleEscKey = (event: KeyboardEvent) => {
+  if (event.key === 'Escape' && props.show) {
+    emit('close')
+  }
+}
+
+// Add and remove event listener
+onMounted(() => {
+  window.addEventListener('keydown', handleEscKey)
+  loadData()
+})
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleEscKey)
+})
 
 // Address normalization helper
 const normalizeAddress = (address: string): string => {

--- a/extension/src/utils/contentInjector.ts
+++ b/extension/src/utils/contentInjector.ts
@@ -608,6 +608,9 @@ export class ContentInjector {
      * Inject status badge component
      */
     private async injectStatusBadge(proposal: DetectedProposal, proposalData: ProposalData | null): Promise<void> {
+        // StatusBadges have been disabled due to rendering issues - September 2025
+        return;
+
         if (!proposal.headerElement) {
             console.warn('No header element found for proposal', proposal.postId);
             return;


### PR DESCRIPTION
__Description__: 
Turns off `StatusBadge`s on main page, under Latest Activity, because they are unstable, and we have other solution for this now, that works.

__What was changed__:
 - turned off `StatusBadge` rendering
 - ESC will close _Team Workflow_ and _Settings_ modals as well

__How was it tested__:
manually tested