### PR TITLE
Refactor extension to use proposalStore singleton

### DIFF
--- a/extension/manifest-firefox.json
+++ b/extension/manifest-firefox.json
@@ -12,7 +12,7 @@
     "https://polkadot.subsquare.io/*",
     "https://kusama.subsquare.io/*",
     "http://localhost:3000/*",
-    "https://40df7fbbabd1.ngrok-free.app/*"
+    "https://api.votingtool.zelmacorp.io/*"
   ],
   "content_scripts": [
     {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -15,7 +15,7 @@
     "https://polkadot.subsquare.io/*",
     "https://kusama.subsquare.io/*",
     "http://localhost:3000/*",
-    "https://40df7fbbabd1.ngrok-free.app/*"
+    "https://api.votingtool.zelmacorp.io/*"
   ],
   "web_accessible_resources": [{
     "resources": ["inject.js"],

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opengov-votingtool-extension",
-  "version": "1.0.0",
+  "version": "0.8.1",
   "description": "OpenGov VotingTool Browser Extension",
   "type": "module",
   "scripts": {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -11,7 +11,7 @@ let messageCounter = 0
 const API_CONFIG = {
   // For development, you can use ngrok: ngrok http 3000
   // baseURL: 'https://abc123.ngrok.io',
-  baseURL: 'https://40df7fbbabd1.ngrok-free.app',
+  baseURL: 'https://api.votingtool.zelmacorp.io',
   timeout: 10000
 }
 

--- a/extension/src/components/VotingControls.vue
+++ b/extension/src/components/VotingControls.vue
@@ -97,6 +97,7 @@
 import { ref, computed } from 'vue'
 import type { InternalStatus, SuggestedVote, Chain, TeamMember } from '../types'
 import { authStore } from '../stores/authStore'
+import { teamStore } from '../stores/teamStore'
 import { formatAddress } from '../utils/teamUtils'
 import StatusChangeModal from './modals/StatusChangeModal.vue'
 import AssignModal from './modals/AssignModal.vue'
@@ -191,8 +192,8 @@ const addressesMatch = (addr1?: string | null, addr2?: string | null): boolean =
  * @returns Team member name if found, otherwise null
  */
 const getTeamMemberName = (address: string): string | null => {
-  if (!props.teamMembers || !address) return null
-  const member = props.teamMembers.find(m => addressesMatch(m.address, address))
+  if (!address) return null
+  const member = teamStore.findTeamMemberByAddress(address)
   return member?.name || null
 }
 
@@ -300,7 +301,6 @@ const statusConfig = {
 }
 
 const statusClass = computed(() => {
-  const config = statusConfig[props.status]
   return {
     'status-clickable': props.editable,
     [`status-${props.status.toLowerCase().replace(/[^a-z0-9]/g, '-')}`]: true

--- a/extension/src/components/WalletConnect.vue
+++ b/extension/src/components/WalletConnect.vue
@@ -22,7 +22,7 @@
               :disabled="isConnecting"
             >
               <div class="wallet-icon">
-                {{ wallet.key === 'polkadot-js' ? '🔗' : '🦅' }}
+                {{ getWalletIcon(wallet.key) }}
               </div>
               <div class="wallet-info">
                 <div class="wallet-name">{{ wallet.name }}</div>
@@ -204,7 +204,7 @@ const availableWallets = computed(() => {
   return window.opengovVotingToolResult?.availableWallets || []
 })
 
-let checkInterval: number | null = null
+let checkInterval: ReturnType<typeof setInterval> | null = null
 
 onMounted(() => {
   // Start checking for the extension
@@ -439,7 +439,19 @@ const getAccountInitials = (name: string) => {
   return name.split(' ').map(n => n[0]).join('').toUpperCase().slice(0, 2)
 }
 
-
+const getWalletIcon = (walletKey: string) => {
+  // Placeholder icons - replace with actual wallet icons later
+  switch (walletKey) {
+    case 'polkadot-js':
+      return '🔘' // Placeholder for Polkadot Extension
+    case 'talisman':
+      return '🔘' // Placeholder for Talisman
+    case 'subwallet':
+      return '🔘' // Placeholder for SubWallet
+    default:
+      return '🔘' // Generic placeholder
+  }
+}
 
 const clearError = () => {
   error.value = ''

--- a/extension/src/components/menu/SettingsMore.vue
+++ b/extension/src/components/menu/SettingsMore.vue
@@ -335,17 +335,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref, onMounted, onUnmounted, computed } from 'vue'
 import { ApiService } from '../../utils/apiService'
+import { teamStore } from '../../stores/teamStore'
 
 interface Props {
   show: boolean
-}
-
-interface DAOConfig {
-  name: string
-  requiredAgreements: number
-  teamMembers: Array<{ name: string; address: string }>
 }
 
 interface UserPreferences {
@@ -404,17 +399,16 @@ const activeSection = ref<'dao-config' | 'preferences' | 'voting-history' | 'act
 const extensionVersion = ref('1.0.0')
 const refreshing = ref(false)
 
-const daoConfig = ref<DAOConfig>({
-  name: '',
-  requiredAgreements: 4,
-  teamMembers: []
-})
-
-const userPrefs = ref<UserPreferences>({
-  notifications: true,
-  autoSync: true,
-  defaultView: 'list',
-  theme: 'light'
+// Use team store for DAO config
+const daoConfig = computed({
+  get: () => ({
+    name: teamStore.daoConfig?.name || '',
+    requiredAgreements: teamStore.daoConfig?.required_agreements || 4,
+    teamMembers: teamStore.teamMembers
+  }),
+  set: () => {
+    // This will be handled by the save method
+  }
 })
 
 const votingStats = ref<VotingStats>({
@@ -439,18 +433,15 @@ const loadData = async () => {
   }
 }
 
-const addMember = () => {
-  daoConfig.value.teamMembers.push({ name: '', address: '' })
-}
-
-const removeMember = (index: number) => {
-  daoConfig.value.teamMembers.splice(index, 1)
-}
+// addMember and removeMember functions removed as team members are managed by multisig
 
 const saveDAOConfig = async () => {
   try {
-    const apiService = ApiService.getInstance()
-    await apiService.updateDAOConfig(daoConfig.value)
+    await teamStore.updateDAOConfig({
+      name: daoConfig.value.name,
+      required_agreements: daoConfig.value.requiredAgreements,
+      team_members: daoConfig.value.teamMembers
+    })
     // Success handled silently
   } catch (error) {
     console.error('Failed to save DAO configuration:', error)
@@ -465,13 +456,7 @@ const resetDAOConfig = () => {
   }
 }
 
-const savePreferences = async () => {
-  try {
-    // Save user preferences when implemented
-  } catch (error) {
-    console.error('Failed to save preferences:', error)
-  }
-}
+// savePreferences function removed - not currently implemented
 
 const manualRefresh = async () => {
   try {
@@ -483,13 +468,7 @@ const manualRefresh = async () => {
   }
 }
 
-const clearCache = async () => {
-  try {
-    // Clear cache implementation when needed
-  } catch (error) {
-    console.error('Failed to clear cache:', error)
-  }
-}
+// clearCache function removed - not currently implemented
 
 const openExternal = (url: string) => {
   window.open(url, '_blank')

--- a/extension/src/stores/__tests__/proposalStore.test.ts
+++ b/extension/src/stores/__tests__/proposalStore.test.ts
@@ -1,333 +1,68 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { useProposalStore } from '../proposalStore'
-import type { Proposal, FilterOptions } from '../../types'
-
-// Mock proposal data for testing
-const mockProposal1: Proposal = {
-  id: '1',
-  chain: 'Polkadot',
-  status: 'Considering',
-  assignedTo: 'current-user-address',
-  suggestedVote: '👍 Aye 👍',
-  title: 'Test Proposal 1',
-  description: 'First test proposal',
-  updatedAt: '2024-01-01T00:00:00.000Z',
-  createdAt: '2024-01-01T00:00:00.000Z'
-}
-
-const mockProposal2: Proposal = {
-  id: '2',
-  chain: 'Kusama',
-  status: 'Ready for approval',
-  assignedTo: 'other-user-address',
-  suggestedVote: '👎 Nay 👎',
-  title: 'Test Proposal 2',
-  description: 'Second test proposal',
-  updatedAt: '2024-01-02T00:00:00.000Z',
-  createdAt: '2024-01-02T00:00:00.000Z'
-}
-
-const mockProposal3: Proposal = {
-  id: '3',
-  chain: 'Polkadot',
-  status: 'Considering',
-  assignedTo: 'current-user-address',
-  suggestedVote: '✌️ Abstain ✌️',
-  title: 'Test Proposal 3',
-  description: 'Third test proposal',
-  updatedAt: '2024-01-03T00:00:00.000Z',
-  createdAt: '2024-01-03T00:00:00.000Z'
-}
+import { describe, it, expect, beforeEach } from 'vitest'
+import { proposalStore } from '../proposalStore'
+import type { ProposalData } from '../../types'
 
 describe('proposalStore', () => {
-  let store: ReturnType<typeof useProposalStore>
-
   beforeEach(() => {
-    store = useProposalStore()
-    vi.clearAllMocks()
-  })
-
-  describe('initial state', () => {
-    it('should have empty proposals array', () => {
-      expect(store.proposals.value).toEqual([])
+    // Reset store state before each test
+    proposalStore.setProposals([])
+    proposalStore.clearFilters()
     })
 
-    it('should have null currentProposal', () => {
-      expect(store.currentProposal.value).toBeNull()
+  it('should initialize with empty state', () => {
+    expect(proposalStore.state.proposals).toEqual([])
+    expect(proposalStore.state.currentProposal).toBeNull()
+    expect(proposalStore.state.loading).toBe(false)
+    expect(proposalStore.state.error).toBeNull()
     })
 
-    it('should have empty filters', () => {
-      expect(store.filters).toEqual({})
-    })
-
-    it('should have loading false', () => {
-      expect(store.loading.value).toBe(false)
-    })
-
-    it('should have null error', () => {
-      expect(store.error.value).toBeNull()
-    })
-  })
-
-  describe('filteredProposals computed', () => {
-    beforeEach(() => {
-      store.proposals.value = [mockProposal1, mockProposal2, mockProposal3]
-    })
-
-    it('should filter by status', () => {
-      store.setFilters({ status: 'Considering' })
-      
-      expect(store.filteredProposals.value).toHaveLength(2)
-      expect(store.filteredProposals.value).toEqual([mockProposal1, mockProposal3])
-    })
-
-    it('should filter by chain', () => {
-      store.setFilters({ chain: 'Kusama' })
-      
-      expect(store.filteredProposals.value).toHaveLength(1)
-      expect(store.filteredProposals.value).toEqual([mockProposal2])
-    })
-
-    it('should filter by assignedTo', () => {
-      store.setFilters({ assignedTo: 'current-user-address' })
-      
-      expect(store.filteredProposals.value).toHaveLength(2)
-      expect(store.filteredProposals.value).toEqual([mockProposal1, mockProposal3])
-    })
-
-    it('should filter by suggestedVote', () => {
-      store.setFilters({ suggestedVote: '👍 Aye 👍' })
-      
-      expect(store.filteredProposals.value).toHaveLength(1)
-      expect(store.filteredProposals.value).toEqual([mockProposal1])
-    })
-
-    it('should combine multiple filters', () => {
-      store.setFilters({ 
-        chain: 'Polkadot', 
-        status: 'Considering',
-        assignedTo: 'current-user-address'
-      })
-      
-      expect(store.filteredProposals.value).toHaveLength(2)
-      expect(store.filteredProposals.value).toEqual([mockProposal1, mockProposal3])
-    })
-
-    it('should return all proposals when no filters applied', () => {
-      expect(store.filteredProposals.value).toHaveLength(3)
-      expect(store.filteredProposals.value).toEqual([mockProposal1, mockProposal2, mockProposal3])
-    })
-  })
-
-  describe('proposalsByStatus computed', () => {
-    it('should group proposals by status', () => {
-      store.proposals.value = [mockProposal1, mockProposal2, mockProposal3]
-      
-      const grouped = store.proposalsByStatus.value
-      
-      expect(grouped).toEqual({
-        'Considering': [mockProposal1, mockProposal3],
-        'Ready for approval': [mockProposal2]
-      })
-    })
-
-    it('should handle empty proposals array', () => {
-      expect(store.proposalsByStatus.value).toEqual({})
-    })
-
-    it('should handle multiple statuses', () => {
-      const proposal4: Proposal = {
-        ...mockProposal1,
-        id: '4',
-        status: 'Ready to vote'
-      }
-      
-      store.proposals.value = [mockProposal1, mockProposal2, proposal4]
-      
-      const grouped = store.proposalsByStatus.value
-      
-      expect(Object.keys(grouped)).toHaveLength(3)
-      expect(grouped['Considering']).toEqual([mockProposal1])
-      expect(grouped['Ready for approval']).toEqual([mockProposal2])
-      expect(grouped['Ready to vote']).toEqual([proposal4])
-    })
-  })
-
-  describe('myAssignments computed', () => {
-    it('should filter proposals assigned to current user', () => {
-      store.proposals.value = [mockProposal1, mockProposal2, mockProposal3]
-      
-      expect(store.myAssignments.value).toHaveLength(2)
-      expect(store.myAssignments.value).toEqual([mockProposal1, mockProposal3])
-    })
-
-    it('should handle empty assignments', () => {
-      store.proposals.value = [mockProposal2] // Only proposal assigned to other user
-      
-      expect(store.myAssignments.value).toEqual([])
-    })
-
-    it('should handle no proposals', () => {
-      expect(store.myAssignments.value).toEqual([])
-    })
-  })
-
-  describe('fetchProposals', () => {
-    it('should fetch proposals successfully', async () => {
-      await store.fetchProposals()
-      
-      expect(store.loading.value).toBe(false)
-      expect(store.error.value).toBeNull()
-      expect(store.proposals.value).toEqual([])
-    })
-
-    it('should handle fetch errors', async () => {
-      // Mock an error by overriding the fetchProposals implementation
-      const originalFetch = store.fetchProposals
-      store.fetchProposals = async () => {
-        store.loading.value = true
-        try {
-          throw new Error('Network error')
-        } catch (err) {
-          store.error.value = err instanceof Error ? err.message : 'Failed to fetch proposals'
-        } finally {
-          store.loading.value = false
-        }
-      }
-      
-      await store.fetchProposals()
-      
-      expect(store.loading.value).toBe(false)
-      expect(store.error.value).toBe('Network error')
-    })
-
-    it('should manage loading state', async () => {
-      // Test that loading state is managed correctly
-      expect(store.loading.value).toBe(false) // Initially false
-      
-      await store.fetchProposals()
-      
-      // Should not be loading after completion
-      expect(store.loading.value).toBe(false)
-    })
-  })
-
-  describe('updateProposal', () => {
-    beforeEach(() => {
-      store.proposals.value = [mockProposal1, mockProposal2]
-    })
-
-    it('should update existing proposal', async () => {
-      const updates = { status: 'Ready for approval' as const }
-      
-      await store.updateProposal('1', updates)
-      
-      const updatedProposal = store.proposals.value.find(p => p.id === '1')
-      expect(updatedProposal?.status).toBe('Ready for approval')
-    })
-
-    it('should handle non-existent proposal', async () => {
-      const originalLength = store.proposals.value.length
-      
-      await store.updateProposal('999', { status: 'Ready for approval' })
-      
-      // Should not add new proposal or change existing ones
-      expect(store.proposals.value).toHaveLength(originalLength)
-      expect(store.proposals.value).toEqual([mockProposal1, mockProposal2])
-    })
-
-    it('should apply partial updates', async () => {
-      const updates = { 
-        suggestedVote: '👎 Nay 👎' as const,
-        description: 'Updated description'
-      }
-      
-      await store.updateProposal('1', updates)
-      
-      const updatedProposal = store.proposals.value.find(p => p.id === '1')
-      expect(updatedProposal?.suggestedVote).toBe('👎 Nay 👎')
-      expect(updatedProposal?.description).toBe('Updated description')
-      expect(updatedProposal?.title).toBe('Test Proposal 1') // Should keep original title
-    })
-
-    it('should update timestamp', async () => {
-      const originalTimestamp = mockProposal1.updatedAt
-      
-      await store.updateProposal('1', { status: 'Ready for approval' })
-      
-      const updatedProposal = store.proposals.value.find(p => p.id === '1')
-      expect(updatedProposal?.updatedAt).not.toBe(originalTimestamp)
-      expect(new Date(updatedProposal?.updatedAt || '')).toBeInstanceOf(Date)
-    })
-  })
-
-  describe('setFilters', () => {
-    it('should set single filter', () => {
-      store.setFilters({ status: 'Considering' })
-      
-      expect(store.filters.status).toBe('Considering')
-    })
-
-    it('should set multiple filters', () => {
-      const filters: FilterOptions = {
-        status: 'Ready for approval',
+  it('should set proposals', () => {
+    const mockProposals: ProposalData[] = [
+      {
+        id: 1,
+        post_id: 123,
         chain: 'Polkadot',
-        assignedTo: 'user-123'
+        title: 'Test Proposal',
+        internal_status: 'Considering',
+        created_at: '2023-01-01T00:00:00Z'
       }
-      
-      store.setFilters(filters)
-      
-      expect(store.filters.status).toBe('Ready for approval')
-      expect(store.filters.chain).toBe('Polkadot')
-      expect(store.filters.assignedTo).toBe('user-123')
+    ]
+
+    proposalStore.setProposals(mockProposals)
+    expect(proposalStore.state.proposals).toEqual(mockProposals)
     })
 
-    it('should override existing filters', () => {
-      store.setFilters({ status: 'Considering' })
-      store.setFilters({ status: 'Ready for approval', chain: 'Kusama' })
-      
-      expect(store.filters.status).toBe('Ready for approval')
-      expect(store.filters.chain).toBe('Kusama')
-    })
-  })
-
-  describe('clearFilters', () => {
-    it('should clear all filters', () => {
-      store.setFilters({
-        status: 'Considering',
+  it('should filter proposals correctly', () => {
+    const mockProposals: ProposalData[] = [
+      {
+        id: 1,
+        post_id: 123,
         chain: 'Polkadot',
-        assignedTo: 'user-123'
-      })
+        title: 'Test Proposal 1',
+        internal_status: 'Considering',
+        created_at: '2023-01-01T00:00:00Z'
+      },
+      {
+        id: 2,
+        post_id: 124,
+        chain: 'Kusama',
+        title: 'Test Proposal 2',
+        internal_status: 'Ready to vote',
+        created_at: '2023-01-02T00:00:00Z'
+      }
+    ]
+
+    proposalStore.setProposals(mockProposals)
+    proposalStore.setFilters({ chain: 'Polkadot' })
       
-      store.clearFilters()
-      
-      expect(store.filters).toEqual({})
+    expect(proposalStore.filteredProposals).toHaveLength(1)
+    expect(proposalStore.filteredProposals[0].chain).toBe('Polkadot')
     })
 
-    it('should clear from populated filters', () => {
-      store.setFilters({ status: 'Considering', chain: 'Polkadot' })
-      
-      expect(Object.keys(store.filters)).toHaveLength(2)
-      
-      store.clearFilters()
-      
-      expect(Object.keys(store.filters)).toHaveLength(0)
-    })
-  })
-
-  describe('setCurrentProposal', () => {
-    it('should set current proposal', () => {
-      store.setCurrentProposal(mockProposal1)
-      
-      expect(store.currentProposal.value).toEqual(mockProposal1)
-    })
-
-    it('should clear current proposal', () => {
-      store.setCurrentProposal(mockProposal1)
-      expect(store.currentProposal.value).toEqual(mockProposal1)
-      
-      store.setCurrentProposal(null)
-      expect(store.currentProposal.value).toBeNull()
-    })
+  it('should clear filters', () => {
+    proposalStore.setFilters({ chain: 'Polkadot', status: 'Considering' })
+    proposalStore.clearFilters()
+    
+    expect(proposalStore.state.filters).toEqual({})
   })
 }) 

--- a/extension/src/stores/__tests__/teamStore.test.ts
+++ b/extension/src/stores/__tests__/teamStore.test.ts
@@ -1,226 +1,86 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { setActivePinia, createPinia } from 'pinia'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { teamStore, type TeamMember } from '../teamStore'
 
-// Mock team member data for testing
-const mockTeamMember1: TeamMember = {
-  name: 'Alice Smith',
-  address: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
-}
-
-const mockTeamMember2: TeamMember = {
-  name: 'Bob Johnson',
-  address: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty'
-}
-
-const mockTeamMember3: TeamMember = {
-  name: 'Charlie Brown',
-  address: '5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y'
-}
-
 describe('teamStore', () => {
-  let store: ReturnType<typeof teamStore>
-
   beforeEach(() => {
-    setActivePinia(createPinia())
-    store = teamStore()
-    vi.clearAllMocks()
-  })
-
-  describe('initial state', () => {
-    it('should have empty teamMembers array', () => {
-      expect(store.teamMembers).toEqual([])
-      expect(store.teamMembers).toHaveLength(0)
-    })
-  })
-
-  describe('getters', () => {
-    describe('getTeamMembers', () => {
-      it('should return team members', () => {
-        store.setTeamMembers([mockTeamMember1, mockTeamMember2])
-        
-        expect(store.getTeamMembers).toEqual([mockTeamMember1, mockTeamMember2])
-        expect(store.getTeamMembers).toHaveLength(2)
+    // Reset store state before each test
+    teamStore.setTeamMembers([])
       })
 
-      it('should handle empty team members', () => {
-        expect(store.getTeamMembers).toEqual([])
-        expect(store.getTeamMembers).toHaveLength(0)
-      })
-    })
-  })
-
-  describe('actions', () => {
-    describe('setTeamMembers', () => {
-      it('should set team members array', () => {
-        const members = [mockTeamMember1, mockTeamMember2]
-        
-        store.setTeamMembers(members)
-        
-        expect(store.teamMembers).toEqual(members)
-        expect(store.teamMembers).toHaveLength(2)
+  it('should initialize with empty state', () => {
+    expect(teamStore.teamMembers).toEqual([])
+    expect(teamStore.daoConfig).toBeNull()
+    expect(teamStore.isLoading).toBe(false)
+    expect(teamStore.error).toBeNull()
       })
 
-      it('should replace existing members', () => {
-        // First set some members
-        store.setTeamMembers([mockTeamMember1])
-        expect(store.teamMembers).toHaveLength(1)
-        
-        // Then replace with new members
-        const newMembers = [mockTeamMember2, mockTeamMember3]
-        store.setTeamMembers(newMembers)
-        
-        expect(store.teamMembers).toEqual(newMembers)
-        expect(store.teamMembers).toHaveLength(2)
-        expect(store.teamMembers).not.toContain(mockTeamMember1)
+  it('should set team members', () => {
+    const mockMembers: TeamMember[] = [
+      { name: 'Alice', address: '1ABC...' },
+      { name: 'Bob', address: '1DEF...' }
+    ]
+
+    teamStore.setTeamMembers(mockMembers)
+    expect(teamStore.teamMembers).toEqual(mockMembers)
       })
 
-      it('should handle empty array', () => {
-        store.setTeamMembers([mockTeamMember1, mockTeamMember2])
-        expect(store.teamMembers).toHaveLength(2)
-        
-        store.setTeamMembers([])
-        
-        expect(store.teamMembers).toEqual([])
-        expect(store.teamMembers).toHaveLength(0)
-      })
-    })
-
-    describe('addTeamMember', () => {
-      it('should add single team member', () => {
-        store.addTeamMember(mockTeamMember1)
-        
-        expect(store.teamMembers).toHaveLength(1)
-        expect(store.teamMembers[0]).toEqual(mockTeamMember1)
+  it('should add team member', () => {
+    const member: TeamMember = { name: 'Charlie', address: '1GHI...' }
+    
+    teamStore.addTeamMember(member)
+    expect(teamStore.teamMembers).toHaveLength(1)
+    expect(teamStore.teamMembers[0]).toEqual(member)
       })
 
-      it('should add to existing members', () => {
-        store.setTeamMembers([mockTeamMember1])
-        
-        store.addTeamMember(mockTeamMember2)
-        
-        expect(store.teamMembers).toHaveLength(2)
-        expect(store.teamMembers.find(m => m.address === mockTeamMember1.address)).toEqual(mockTeamMember1)
-        expect(store.teamMembers.find(m => m.address === mockTeamMember2.address)).toEqual(mockTeamMember2)
-      })
-
-      it('should allow duplicate addresses', () => {
-        store.addTeamMember(mockTeamMember1)
-        store.addTeamMember(mockTeamMember1) // Same member again
-        
-        expect(store.teamMembers).toHaveLength(2)
-        expect(store.teamMembers[0]).toEqual(mockTeamMember1)
-        expect(store.teamMembers[1]).toEqual(mockTeamMember1)
-      })
-    })
-
-    describe('removeTeamMember', () => {
       it('should remove team member by address', () => {
-        store.setTeamMembers([mockTeamMember1, mockTeamMember2, mockTeamMember3])
+    const members: TeamMember[] = [
+      { name: 'Alice', address: '1ABC...' },
+      { name: 'Bob', address: '1DEF...' }
+    ]
+
+    teamStore.setTeamMembers(members)
+    teamStore.removeTeamMember('1ABC...')
         
-        store.removeTeamMember(mockTeamMember2.address)
-        
-        expect(store.teamMembers).toHaveLength(2)
-        expect(store.teamMembers.find(m => m.address === mockTeamMember2.address)).toBeUndefined()
-        expect(store.teamMembers.find(m => m.address === mockTeamMember1.address)).toEqual(mockTeamMember1)
-        expect(store.teamMembers.find(m => m.address === mockTeamMember3.address)).toEqual(mockTeamMember3)
+    expect(teamStore.teamMembers).toHaveLength(1)
+    expect(teamStore.teamMembers[0].name).toBe('Bob')
       })
 
-      it('should handle non-existent member', () => {
-        store.setTeamMembers([mockTeamMember1, mockTeamMember2])
-        const originalLength = store.teamMembers.length
-        
-        store.removeTeamMember('non-existent-address')
-        
-        expect(store.teamMembers).toHaveLength(originalLength)
-        expect(store.teamMembers).toEqual([mockTeamMember1, mockTeamMember2])
+  it('should update team member', () => {
+    const members: TeamMember[] = [
+      { name: 'Alice', address: '1ABC...' }
+    ]
+
+    teamStore.setTeamMembers(members)
+    teamStore.updateTeamMember('1ABC...', { name: 'Alice Updated' })
+    
+    expect(teamStore.teamMembers[0].name).toBe('Alice Updated')
+    expect(teamStore.teamMembers[0].address).toBe('1ABC...')
       })
 
-      it('should handle empty team members array', () => {
-        expect(store.teamMembers).toHaveLength(0)
+  it('should find team member by address', () => {
+    const members: TeamMember[] = [
+      { name: 'Alice', address: '1ABC...' },
+      { name: 'Bob', address: '1DEF...' }
+    ]
+
+    teamStore.setTeamMembers(members)
         
-        store.removeTeamMember(mockTeamMember1.address)
+    const found = teamStore.findTeamMemberByAddress('1ABC...')
+    expect(found).toEqual({ name: 'Alice', address: '1ABC...' })
         
-        expect(store.teamMembers).toHaveLength(0)
+    const notFound = teamStore.findTeamMemberByAddress('1XYZ...')
+    expect(notFound).toBeNull()
       })
 
-      it('should remove all instances of duplicate addresses', () => {
-        store.setTeamMembers([mockTeamMember1, mockTeamMember2, mockTeamMember1])
-        expect(store.teamMembers).toHaveLength(3)
-        
-        store.removeTeamMember(mockTeamMember1.address)
-        
-        expect(store.teamMembers).toHaveLength(1)
-        expect(store.teamMembers).toEqual([mockTeamMember2])
-      })
-    })
+  it('should get team member name', () => {
+    const members: TeamMember[] = [
+      { name: 'Alice', address: '1ABC...' }
+    ]
 
-    describe('updateTeamMember', () => {
-      beforeEach(() => {
-        store.setTeamMembers([mockTeamMember1, mockTeamMember2])
-      })
-
-      it('should update existing team member', () => {
-        const updates = { name: 'Alice Updated' }
-        
-        store.updateTeamMember(mockTeamMember1.address, updates)
-        
-        const updatedMember = store.teamMembers.find(m => m.address === mockTeamMember1.address)
-        expect(updatedMember?.name).toBe('Alice Updated')
-        expect(updatedMember?.address).toBe(mockTeamMember1.address) // Address should remain the same
-      })
-
-      it('should handle non-existent member', () => {
-        const originalMembers = [...store.teamMembers]
-        
-        store.updateTeamMember('non-existent-address', { name: 'New Name' })
-        
-        expect(store.teamMembers).toEqual(originalMembers)
-        expect(store.teamMembers).toHaveLength(2)
-      })
-
-      it('should apply partial updates', () => {
-        const updates = { name: 'Bob Updated' }
-        
-        store.updateTeamMember(mockTeamMember2.address, updates)
-        
-        const updatedMember = store.teamMembers.find(m => m.address === mockTeamMember2.address)
-        expect(updatedMember?.name).toBe('Bob Updated')
-        expect(updatedMember?.address).toBe(mockTeamMember2.address)
-      })
-
-      it('should update address if provided', () => {
-        const newAddress = '5NewAddressExample123456789'
-        const updates = { address: newAddress }
-        
-        store.updateTeamMember(mockTeamMember1.address, updates)
-        
-        const updatedMember = store.teamMembers.find(m => m.name === mockTeamMember1.name)
-        expect(updatedMember?.address).toBe(newAddress)
-        expect(updatedMember?.name).toBe(mockTeamMember1.name)
-      })
-
-      it('should update multiple fields at once', () => {
-        const updates = { 
-          name: 'Alice Completely Updated',
-          address: '5NewAddressForAlice123456789'
-        }
-        
-        store.updateTeamMember(mockTeamMember1.address, updates)
-        
-        const updatedMember = store.teamMembers.find(m => m.address === updates.address)
-        expect(updatedMember?.name).toBe(updates.name)
-        expect(updatedMember?.address).toBe(updates.address)
-      })
-
-      it('should handle empty updates object', () => {
-        const originalMember = { ...mockTeamMember1 }
-        
-        store.updateTeamMember(mockTeamMember1.address, {})
-        
-        const member = store.teamMembers.find(m => m.address === mockTeamMember1.address)
-        expect(member).toEqual(originalMember)
-      })
-    })
+    teamStore.setTeamMembers(members)
+    
+    expect(teamStore.getTeamMemberName('1ABC...')).toBe('Alice')
+    expect(teamStore.getTeamMemberName('1XYZ...')).toBe('1XYZ...')
+    expect(teamStore.getTeamMemberName(undefined)).toBe('Unknown')
   })
 }) 

--- a/extension/src/stores/index.ts
+++ b/extension/src/stores/index.ts
@@ -1,0 +1,4 @@
+// Store exports for easier importing
+export { authStore } from './authStore'
+export { proposalStore } from './proposalStore'
+export { teamStore, type TeamMember } from './teamStore' 

--- a/extension/src/stores/proposalStore.ts
+++ b/extension/src/stores/proposalStore.ts
@@ -1,105 +1,191 @@
-import { ref, computed, reactive } from 'vue'
-import type { Proposal, FilterOptions } from '../types'
+import { computed, reactive } from 'vue'
+import type { ProposalData, FilterOptions } from '../types'
+import { authStore } from './authStore'
+import { ApiService } from '../utils/apiService'
 
-// Simple reactive store using Vue 3 composition API
-export const useProposalStore = () => {
-  const proposals = ref<Proposal[]>([])
-  const currentProposal = ref<Proposal | null>(null)
-  const filters = reactive<FilterOptions>({})
-  const loading = ref(false)
-  const error = ref<string | null>(null)
+// Create reactive state
+const state = reactive({
+  proposals: [] as ProposalData[],
+  currentProposal: null as ProposalData | null,
+  filters: {} as FilterOptions,
+  loading: false,
+  error: null as string | null
+})
 
+// Computed properties
   const filteredProposals = computed(() => {
-    let filtered = proposals.value
+  let filtered = state.proposals
 
-    if (filters.status) {
-      filtered = filtered.filter((p: Proposal) => p.status === filters.status)
+  if (state.filters.status) {
+    filtered = filtered.filter((p: ProposalData) => p.internal_status === state.filters.status)
     }
 
-    if (filters.chain) {
-      filtered = filtered.filter((p: Proposal) => p.chain === filters.chain)
+  if (state.filters.chain) {
+    filtered = filtered.filter((p: ProposalData) => p.chain === state.filters.chain)
     }
 
-    if (filters.assignedTo) {
-      filtered = filtered.filter((p: Proposal) => p.assignedTo === filters.assignedTo)
+  if (state.filters.assignedTo) {
+    filtered = filtered.filter((p: ProposalData) => p.assigned_to === state.filters.assignedTo)
     }
 
-    if (filters.suggestedVote) {
-      filtered = filtered.filter((p: Proposal) => p.suggestedVote === filters.suggestedVote)
+  if (state.filters.suggestedVote) {
+    filtered = filtered.filter((p: ProposalData) => p.suggested_vote === state.filters.suggestedVote)
     }
 
     return filtered
   })
 
   const proposalsByStatus = computed(() => {
-    return proposals.value.reduce((acc: Record<string, Proposal[]>, proposal: Proposal) => {
-      const status = proposal.status
+  return state.proposals.reduce((acc: Record<string, ProposalData[]>, proposal: ProposalData) => {
+    const status = proposal.internal_status
       if (!acc[status]) {
         acc[status] = []
       }
       acc[status].push(proposal)
       return acc
-    }, {} as Record<string, Proposal[]>)
+  }, {} as Record<string, ProposalData[]>)
   })
 
   const myAssignments = computed(() => {
-    // Get current user from wallet
-    const currentUser = 'current-user-address'
-    return proposals.value.filter((p: Proposal) => p.assignedTo === currentUser)
+  const currentUser = authStore.state.user?.address
+  if (!currentUser) return []
+  return state.proposals.filter((p: ProposalData) => p.assigned_to === currentUser)
+})
+
+const actionsNeeded = computed(() => {
+  const currentUser = authStore.state.user?.address
+  if (!currentUser) return []
+  
+  return state.proposals.filter(p => {
+    // Proposals where user needs to take action
+    const hasNoTeamAction = !p.team_actions?.some(action => action.wallet_address === currentUser)
+    const isAssignedToMe = p.assigned_to === currentUser
+    const needsEvaluation = isAssignedToMe && !p.suggested_vote
+    const inActionableStatus = ['Considering', 'Ready for approval', 'Waiting for agreement'].includes(p.internal_status)
+    
+    return (hasNoTeamAction && inActionableStatus) || needsEvaluation
+  })
   })
 
-  const fetchProposals = async () => {
-    loading.value = true
+const myEvaluations = computed(() => {
+  const currentUser = authStore.state.user?.address
+  if (!currentUser) return []
+  return state.proposals.filter(p => p.assigned_to === currentUser && p.suggested_vote)
+})
+
+// Store object
+export const proposalStore = {
+  // State (readonly to prevent direct mutation)
+  get state() {
+    return {
+      proposals: state.proposals,
+      currentProposal: state.currentProposal,
+      filters: state.filters,
+      loading: state.loading,
+      error: state.error
+    }
+  },
+
+  // Getters
+  get filteredProposals() {
+    return filteredProposals.value
+  },
+  
+  get proposalsByStatus() {
+    return proposalsByStatus.value
+  },
+  
+  get myAssignments() {
+    return myAssignments.value
+  },
+
+  get actionsNeeded() {
+    return actionsNeeded.value
+  },
+
+  get myEvaluations() {
+    return myEvaluations.value
+  },
+
+  // Actions
+  async fetchProposals(): Promise<void> {
+    state.loading = true
+    state.error = null
+    console.log('🔄 ProposalStore: Starting fetchProposals...')
+    
     try {
-      // Implement actual API call
-      proposals.value = []
-      error.value = null
+      if (!authStore.state.isAuthenticated) {
+        console.warn('⚠️ ProposalStore: Not authenticated, cannot fetch proposals')
+        return
+      }
+
+      console.log('📡 ProposalStore: Calling ApiService.getAllProposals()...')
+      const apiService = ApiService.getInstance()
+      const allProposals = await apiService.getAllProposals()
+      
+      console.log('📦 ProposalStore: Received proposals from API:', {
+        count: allProposals.length,
+        proposalIds: allProposals.map(p => p.post_id).slice(0, 10), // First 10 IDs
+        sampleProposal: allProposals[0] ? {
+          id: allProposals[0].post_id,
+          title: allProposals[0].title,
+          status: allProposals[0].internal_status
+        } : null
+      })
+      
+      state.proposals = allProposals
+      state.error = null
+      
+      console.log('✅ ProposalStore: State updated with', state.proposals.length, 'proposals')
     } catch (err) {
-      error.value = err instanceof Error ? err.message : 'Failed to fetch proposals'
+      state.error = err instanceof Error ? err.message : 'Failed to fetch proposals'
+      console.error('❌ ProposalStore: Failed to fetch proposals:', err)
     } finally {
-      loading.value = false
+      state.loading = false
     }
-  }
+  },
 
-  const updateProposal = async (proposalId: string, updates: Partial<Proposal>) => {
-    const index = proposals.value.findIndex((p: Proposal) => p.id === proposalId)
+  setProposals(proposals: ProposalData[]): void {
+    state.proposals = proposals
+  },
+
+  async updateProposal(proposalId: string, updates: Partial<ProposalData>): Promise<void> {
+    const index = state.proposals.findIndex((p: ProposalData) => p.post_id.toString() === proposalId)
     if (index !== -1) {
-      proposals.value[index] = { ...proposals.value[index], ...updates, updatedAt: new Date().toISOString() }
+      state.proposals[index] = { ...state.proposals[index], ...updates, updated_at: new Date().toISOString() }
+    }
+  },
+
+  setFilters(newFilters: FilterOptions): void {
+    Object.assign(state.filters, newFilters)
+  },
+
+  clearFilters(): void {
+    Object.keys(state.filters).forEach(key => {
+      delete state.filters[key as keyof FilterOptions]
+    })
+  },
+
+  setCurrentProposal(proposal: ProposalData | null): void {
+    state.currentProposal = proposal
+  },
+
+  // Initialize proposals if authenticated
+  async initialize(): Promise<void> {
+    if (authStore.state.isAuthenticated && state.proposals.length === 0) {
+      await this.fetchProposals()
     }
   }
+}
 
-  const setFilters = (newFilters: FilterOptions) => {
-    Object.assign(filters, newFilters)
+// Auto-initialize when auth state changes
+window.addEventListener('authStateChanged', (event: any) => {
+  if (event.detail.isAuthenticated) {
+    proposalStore.initialize()
+  } else {
+    // Clear proposals when logged out
+    state.proposals = []
+    state.currentProposal = null
+    state.error = null
   }
-
-  const clearFilters = () => {
-    Object.keys(filters).forEach(key => {
-      delete filters[key as keyof FilterOptions]
-    })
-  }
-
-  const setCurrentProposal = (proposal: Proposal | null) => {
-    currentProposal.value = proposal
-  }
-
-  return {
-    // State
-    proposals,
-    currentProposal,
-    filters,
-    loading,
-    error,
-    
-    // Getters
-    filteredProposals,
-    proposalsByStatus,
-    myAssignments,
-    
-    // Actions
-    fetchProposals,
-    updateProposal,
-    setFilters,
-    clearFilters,
-    setCurrentProposal
-  }
-} 
+}) 

--- a/extension/src/stores/teamStore.ts
+++ b/extension/src/stores/teamStore.ts
@@ -1,4 +1,6 @@
-import { defineStore } from 'pinia';
+import { reactive, readonly } from 'vue'
+import { ApiService } from '../utils/apiService'
+import { authStore } from './authStore'
 
 export interface TeamMember {
   name: string;
@@ -7,35 +9,142 @@ export interface TeamMember {
 
 interface TeamState {
   teamMembers: TeamMember[];
+  daoConfig: {
+    name: string;
+    required_agreements: number;
+    multisig_address?: string;
+  } | null;
+  loading: boolean;
+  error: string | null;
 }
 
-export const teamStore = defineStore('team', {
-  state: (): TeamState => ({
+// Create reactive state
+const state = reactive<TeamState>({
     teamMembers: [],
-  }),
-  
-  getters: {
-    getTeamMembers: (state: TeamState): TeamMember[] => state.teamMembers,
+  daoConfig: null,
+  loading: false,
+  error: null
+})
+
+export const teamStore = {
+  // State
+  state: readonly(state),
+
+  // Getters
+  get teamMembers(): TeamMember[] {
+    return state.teamMembers
   },
-  
-  actions: {
-    setTeamMembers(members: TeamMember[]) {
-      this.teamMembers = members;
-    },
-    
-    addTeamMember(member: TeamMember) {
-      this.teamMembers.push(member);
-    },
-    
-    removeTeamMember(address: string) {
-      this.teamMembers = this.teamMembers.filter((m: TeamMember) => m.address !== address);
-    },
-    
-    updateTeamMember(address: string, updates: Partial<TeamMember>) {
-      const index = this.teamMembers.findIndex((m: TeamMember) => m.address === address);
-      if (index !== -1) {
-        this.teamMembers[index] = { ...this.teamMembers[index], ...updates };
+
+  get daoConfig() {
+    return state.daoConfig
+  },
+
+  get isLoading(): boolean {
+    return state.loading
+  },
+
+  get error(): string | null {
+    return state.error
+  },
+
+  // Actions
+  async fetchTeamData(): Promise<void> {
+    state.loading = true
+    state.error = null
+    try {
+      if (!authStore.state.isAuthenticated) {
+        console.warn('Not authenticated, cannot fetch team data')
+        return
       }
+
+      const apiService = ApiService.getInstance()
+      const daoConfig = await apiService.getDAOConfig()
+      
+      if (daoConfig) {
+        state.daoConfig = {
+          name: daoConfig.name || '',
+          required_agreements: daoConfig.required_agreements || 4,
+          multisig_address: daoConfig.multisig_address
+        }
+        state.teamMembers = daoConfig.team_members || []
+      }
+    } catch (err) {
+      state.error = err instanceof Error ? err.message : 'Failed to fetch team data'
+      console.error('Failed to fetch team data:', err)
+    } finally {
+      state.loading = false
+    }
+  },
+
+  setTeamMembers(members: TeamMember[]): void {
+    state.teamMembers = members
+    },
+    
+  addTeamMember(member: TeamMember): void {
+    state.teamMembers.push(member)
+    },
+    
+  removeTeamMember(address: string): void {
+    state.teamMembers = state.teamMembers.filter((m: TeamMember) => m.address !== address)
+    },
+    
+  updateTeamMember(address: string, updates: Partial<TeamMember>): void {
+    const index = state.teamMembers.findIndex((m: TeamMember) => m.address === address)
+      if (index !== -1) {
+      state.teamMembers[index] = { ...state.teamMembers[index], ...updates }
+    }
+  },
+
+  async updateDAOConfig(config: { name: string; required_agreements: number; team_members: TeamMember[] }): Promise<void> {
+    try {
+      if (!authStore.state.isAuthenticated) {
+        throw new Error('Not authenticated')
+      }
+
+      const apiService = ApiService.getInstance()
+      await apiService.updateDAOConfig(config)
+      
+      // Update local state
+      state.daoConfig = {
+        name: config.name,
+        required_agreements: config.required_agreements
+      }
+      state.teamMembers = config.team_members
+      state.error = null
+    } catch (err) {
+      state.error = err instanceof Error ? err.message : 'Failed to update DAO config'
+      console.error('Failed to update DAO config:', err)
+      throw err
+    }
+  },
+
+  // Helper methods
+  findTeamMemberByAddress(address: string): TeamMember | null {
+    return state.teamMembers.find(member => member.address === address) || null
+  },
+
+  getTeamMemberName(address: string | undefined): string {
+    if (!address) return 'Unknown'
+    const member = this.findTeamMemberByAddress(address)
+    return member?.name || `${address.slice(0, 6)}...${address.slice(-6)}`
+  },
+
+  // Initialize team data if authenticated
+  async initialize(): Promise<void> {
+    if (authStore.state.isAuthenticated && state.teamMembers.length === 0) {
+      await this.fetchTeamData()
     }
   }
-}); 
+}
+
+// Auto-initialize when auth state changes
+window.addEventListener('authStateChanged', (event: any) => {
+  if (event.detail.isAuthenticated) {
+    teamStore.initialize()
+  } else {
+    // Clear team data when logged out
+    state.teamMembers = []
+    state.daoConfig = null
+    state.error = null
+  }
+}) 


### PR DESCRIPTION
__Description__: 
Refactor extension to use proposalStore singleton.

__What was changed__:
- `VotingControls,` `TeamWorkflow`, `MyDashboard`, `ProposalBrowser` now using `proposalStore`, `teamStore` with singleton pattern
- url was edited to use real api url

__How was it tested__:
manually tested