### PR TITLE
Remove tabs and activeTab from manifests

### DIFF
--- a/extension/manifest-firefox.json
+++ b/extension/manifest-firefox.json
@@ -4,8 +4,6 @@
   "version": "1.0.0",
   "description": "A browser extension that overlays on Polkassembly and Subsquare to help you vote on OpenGov proposals",
   "permissions": [
-    "activeTab",
-    "scripting",
     "storage",
     "https://polkadot.polkassembly.io/*",
     "https://kusama.polkassembly.io/*",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,10 +4,8 @@
   "version": "1.0.0",
   "description": "A browser extension that overlays on Polkassembly and Subsquare to help you vote on OpenGov proposals",
   "permissions": [
-    "activeTab",
     "scripting",
-    "storage",
-    "tabs"
+    "storage"
   ],
   "host_permissions": [
     "https://polkadot.polkassembly.io/*",

--- a/extension/src/components/WalletConnect.vue
+++ b/extension/src/components/WalletConnect.vue
@@ -377,7 +377,7 @@ const handleSignMessage = async () => {
     
     // Wait for the signature result
     let attempts = 0
-    const maxAttempts = 20 // Wait up to 10 seconds
+    const maxAttempts = 160 // Wait up to 80 seconds (1min 20s)
     
     console.log('⏳ Waiting for signature result...')
     

--- a/extension/src/test/setup.ts
+++ b/extension/src/test/setup.ts
@@ -18,13 +18,6 @@ global.chrome = {
     },
     lastError: null,
   },
-  tabs: {
-    query: vi.fn(),
-    sendMessage: vi.fn(),
-  },
-  scripting: {
-    executeScript: vi.fn(),
-  },
 } as any
 
 // Mock Firefox browser APIs
@@ -45,13 +38,6 @@ global.window = {
         addListener: vi.fn(),
         removeListener: vi.fn(),
       },
-    },
-    tabs: {
-      query: vi.fn(),
-      sendMessage: vi.fn(),
-    },
-    scripting: {
-      executeScript: vi.fn(),
     },
   },
 } as any

--- a/extension/src/types/browser.d.ts
+++ b/extension/src/types/browser.d.ts
@@ -24,15 +24,6 @@ declare namespace chrome {
     };
   };
   
-  const tabs: {
-    query(queryInfo: any): Promise<any[]>;
-    sendMessage(tabId: number, message: any): Promise<any>;
-  };
-  
-  const scripting: {
-    executeScript(injection: any): Promise<any>;
-  };
-  
   const runtime: {
     id: string;
     sendMessage(message: any): Promise<any>;
@@ -54,20 +45,6 @@ declare namespace browser {
       addListener: (callback: (message: any, sender: any) => void) => void;
       removeListener: (callback: (message: any, sender: any) => void) => void;
     };
-  };
-  
-  const tabs: {
-    query: (queryInfo: { active: boolean; currentWindow: boolean }) => Promise<any[]>;
-    sendMessage: (tabId: number, message: any) => Promise<any>;
-    executeScript: (tabId: number, details: { file: string }) => Promise<any>;
-  };
-  
-  const scripting: {
-    executeScript: (injection: {
-      target: { tabId: number };
-      files?: string[];
-      func?: () => void;
-    }) => Promise<any>;
   };
   
   const storage: {

--- a/extension/src/utils/__tests__/browser.test.ts
+++ b/extension/src/utils/__tests__/browser.test.ts
@@ -17,13 +17,6 @@ const mockFirefoxBrowser = {
       set: vi.fn(),
       remove: vi.fn()
     }
-  },
-  tabs: {
-    query: vi.fn(),
-    sendMessage: vi.fn()
-  },
-  scripting: {
-    executeScript: vi.fn()
   }
 }
 
@@ -42,13 +35,6 @@ const mockChromeBrowser = {
       set: vi.fn(),
       remove: vi.fn()
     }
-  },
-  tabs: {
-    query: vi.fn(),
-    sendMessage: vi.fn()
-  },
-  scripting: {
-    executeScript: vi.fn()
   }
 }
 
@@ -163,8 +149,6 @@ describe('browser utilities', () => {
       expect(api).toBe(mockFirefoxBrowser)
       expect(api.runtime.id).toBe('firefox-extension-id')
       expect(typeof api.storage.local.get).toBe('function')
-      expect(typeof api.tabs.query).toBe('function')
-      expect(typeof api.scripting.executeScript).toBe('function')
     })
 
     it('should return Chrome API when available', () => {
@@ -176,8 +160,6 @@ describe('browser utilities', () => {
       expect(api).toBe(mockChromeBrowser)
       expect(api.runtime.id).toBe('chrome-extension-id')
       expect(typeof api.storage.local.get).toBe('function')
-      expect(typeof api.tabs.query).toBe('function')
-      expect(typeof api.scripting.executeScript).toBe('function')
     })
 
     it('should throw error for unsupported browsers', () => {
@@ -214,15 +196,6 @@ describe('browser utilities', () => {
       expect(typeof api.storage.local.set).toBe('function')
       expect(typeof api.storage.local.remove).toBe('function')
       
-      // Check tabs API
-      expect(api.tabs).toBeDefined()
-      expect(typeof api.tabs.query).toBe('function')
-      expect(typeof api.tabs.sendMessage).toBe('function')
-      
-      // Check scripting API
-      expect(api.scripting).toBeDefined()
-      expect(typeof api.scripting.executeScript).toBe('function')
-      
       // Check runtime API
       expect(api.runtime).toBeDefined()
       expect(typeof api.runtime.id).toBe('string')
@@ -243,15 +216,6 @@ describe('browser utilities', () => {
       expect(typeof api.storage.local.get).toBe('function')
       expect(typeof api.storage.local.set).toBe('function')
       expect(typeof api.storage.local.remove).toBe('function')
-      
-      // Check tabs API
-      expect(api.tabs).toBeDefined()
-      expect(typeof api.tabs.query).toBe('function')
-      expect(typeof api.tabs.sendMessage).toBe('function')
-      
-      // Check scripting API
-      expect(api.scripting).toBeDefined()
-      expect(typeof api.scripting.executeScript).toBe('function')
       
       // Check runtime API
       expect(api.runtime).toBeDefined()
@@ -376,9 +340,6 @@ describe('browser utilities', () => {
         'storage.local.get',
         'storage.local.set', 
         'storage.local.remove',
-        'tabs.query',
-        'tabs.sendMessage',
-        'scripting.executeScript',
         'runtime.sendMessage',
         'runtime.onMessage.addListener',
         'runtime.onMessage.removeListener'
@@ -451,9 +412,6 @@ describe('browser utilities', () => {
       expect(typeof api.storage.local.get).toBe('function')
       expect(typeof api.storage.local.set).toBe('function')
       expect(typeof api.storage.local.remove).toBe('function')
-      expect(typeof api.tabs.query).toBe('function')
-      expect(typeof api.tabs.sendMessage).toBe('function')
-      expect(typeof api.scripting.executeScript).toBe('function')
       expect(typeof api.runtime.sendMessage).toBe('function')
       expect(typeof api.runtime.onMessage.addListener).toBe('function')
       expect(typeof api.runtime.onMessage.removeListener).toBe('function')
@@ -469,8 +427,6 @@ describe('browser utilities', () => {
       const firefoxStructure = {
         hasStorage: !!firefoxAPI.storage,
         hasStorageLocal: !!firefoxAPI.storage?.local,
-        hasTabs: !!firefoxAPI.tabs,
-        hasScripting: !!firefoxAPI.scripting,
         hasRuntime: !!firefoxAPI.runtime,
         hasOnMessage: !!firefoxAPI.runtime?.onMessage
       }
@@ -483,8 +439,6 @@ describe('browser utilities', () => {
       const chromeStructure = {
         hasStorage: !!chromeAPI.storage,
         hasStorageLocal: !!chromeAPI.storage?.local,
-        hasTabs: !!chromeAPI.tabs,
-        hasScripting: !!chromeAPI.scripting,
         hasRuntime: !!chromeAPI.runtime,
         hasOnMessage: !!chromeAPI.runtime?.onMessage
       }

--- a/extension/src/utils/__tests__/messaging.test.ts
+++ b/extension/src/utils/__tests__/messaging.test.ts
@@ -256,52 +256,7 @@ describe('messaging utilities', () => {
       })
     })
 
-    it('should handle tab access errors', () => {
-      const tabErrors = [
-        'Cannot access contents of the page',
-        'No tab with id: 999',
-        'Tab not found',
-        'Tabs permission denied'
-      ]
 
-      tabErrors.forEach(errorMessage => {
-        const handleTabError = (error: Error) => {
-          console.error('Tab error:', error)
-          return null
-        }
-
-        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-        const result = handleTabError(new Error(errorMessage))
-
-        expect(result).toBeNull()
-        expect(consoleSpy).toHaveBeenCalledWith('Tab error:', expect.any(Error))
-
-        consoleSpy.mockRestore()
-      })
-    })
-
-    it('should handle script execution errors', () => {
-      const scriptErrors = [
-        'Script execution failed',
-        'Cannot access contents of the page',
-        'Invalid script target'
-      ]
-
-      scriptErrors.forEach(errorMessage => {
-        const handleScriptError = (error: Error) => {
-          console.error('Script execution error:', error)
-          return null
-        }
-
-        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-        const result = handleScriptError(new Error(errorMessage))
-
-        expect(result).toBeNull()
-        expect(consoleSpy).toHaveBeenCalledWith('Script execution error:', expect.any(Error))
-
-        consoleSpy.mockRestore()
-      })
-    })
 
     it('should handle non-Error exceptions', () => {
       const createErrorResponse = (error: any): MessageResponse => {
@@ -641,10 +596,7 @@ describe('messaging utilities', () => {
         const requiredMethods = [
           'runtime.sendMessage',
           'runtime.onMessage.addListener',
-          'runtime.onMessage.removeListener',
-          'tabs.query',
-          'tabs.sendMessage',
-          'scripting.executeScript'
+          'runtime.onMessage.removeListener'
         ]
 
         return requiredMethods.every(method => {
@@ -668,13 +620,6 @@ describe('messaging utilities', () => {
             addListener: vi.fn(),
             removeListener: vi.fn()
           }
-        },
-        tabs: {
-          query: vi.fn(),
-          sendMessage: vi.fn()
-        },
-        scripting: {
-          executeScript: vi.fn()
         }
       }
       expect(checkAPIAvailability(completeAPI)).toBe(true)
@@ -696,10 +641,7 @@ describe('messaging utilities', () => {
         return {
           sendMessage: api?.runtime?.sendMessage,
           addListener: api?.runtime?.onMessage?.addListener,
-          removeListener: api?.runtime?.onMessage?.removeListener,
-          queryTabs: api?.tabs?.query,
-          sendMessageToTab: api?.tabs?.sendMessage,
-          executeScript: api?.scripting?.executeScript
+          removeListener: api?.runtime?.onMessage?.removeListener
         }
       }
 
@@ -707,16 +649,14 @@ describe('messaging utilities', () => {
         runtime: { 
           sendMessage: vi.fn(), 
           onMessage: { addListener: vi.fn(), removeListener: vi.fn() } 
-        },
-        tabs: { query: vi.fn(), sendMessage: vi.fn() },
-        scripting: { executeScript: vi.fn() }
+        }
       }
 
       const unifiedAPI = createUnifiedAPI(firefoxAPI, null)
 
       expect(typeof unifiedAPI.sendMessage).toBe('function')
       expect(typeof unifiedAPI.addListener).toBe('function')
-      expect(typeof unifiedAPI.queryTabs).toBe('function')
+      expect(typeof unifiedAPI.removeListener).toBe('function')
     })
   })
 }) 

--- a/extension/src/utils/browser.ts
+++ b/extension/src/utils/browser.ts
@@ -8,13 +8,6 @@ export interface BrowserAPI {
       remove(keys: string[]): Promise<void>;
     };
   };
-  tabs: {
-    query(queryInfo: any): Promise<any[]>;
-    sendMessage(tabId: number, message: any): Promise<any>;
-  };
-  scripting: {
-    executeScript(injection: any): Promise<any>;
-  };
   runtime: {
     id: string;
     sendMessage(message: any): Promise<any>;

--- a/extension/src/utils/messaging.ts
+++ b/extension/src/utils/messaging.ts
@@ -27,28 +27,6 @@ const getRuntimeAPI = () => {
   }
 };
 
-// Get the appropriate tabs API
-const getTabsAPI = () => {
-  if (isFirefox) {
-    return (window as any).browser.tabs;
-  } else if (isChrome) {
-    return chrome.tabs;
-  } else {
-    throw new Error('No supported browser tabs API found');
-  }
-};
-
-// Get the appropriate scripting API
-const getScriptingAPI = () => {
-  if (isFirefox) {
-    return (window as any).browser.scripting;
-  } else if (isChrome) {
-    return chrome.scripting;
-  } else {
-    throw new Error('No supported browser scripting API found');
-  }
-};
-
 export const messaging = {
   // Send message to background script
   async sendMessage(message: Message): Promise<MessageResponse> {
@@ -78,42 +56,6 @@ export const messaging = {
       runtimeAPI.onMessage.removeListener(callback);
     } catch (error) {
       console.error('Remove message listener error:', error);
-    }
-  },
-
-  // Query tabs
-  async queryTabs(queryInfo: any): Promise<any[]> {
-    try {
-      const tabsAPI = getTabsAPI();
-      return await tabsAPI.query(queryInfo);
-    } catch (error) {
-      console.error('Query tabs error:', error);
-      return [];
-    }
-  },
-
-  // Send message to specific tab
-  async sendMessageToTab(tabId: number, message: Message): Promise<any> {
-    try {
-      const tabsAPI = getTabsAPI();
-      return await tabsAPI.sendMessage(tabId, message);
-    } catch (error) {
-      console.error('Send message to tab error:', error);
-      return null;
-    }
-  },
-
-  // Execute script in tab
-  async executeScript(tabId: number, func: Function): Promise<any> {
-    try {
-      const scriptingAPI = getScriptingAPI();
-      return await scriptingAPI.executeScript({
-        target: { tabId },
-        func: func.toString()
-      });
-    } catch (error) {
-      console.error('Execute script error:', error);
-      return null;
     }
   }
 }; 


### PR DESCRIPTION
__Description__: 
Remove `tabs` and `activeTab` from chrome and firefox manifests, and also removed some associated dead code.

__What was changed__:
- removed `activeTab`, `scripting` from firefox manifest
- removed `activeTab`, `tabs` from chrome manifest
- removed some associated dead code from setup.ts, browser.d.ts
- removed some related code from tests 

__How was it tested__:
`npm run test`